### PR TITLE
Add advanced phishing awareness exercises documentation

### DIFF
--- a/docs/subcase-1a-phishing-awareness.md
+++ b/docs/subcase-1a-phishing-awareness.md
@@ -21,13 +21,41 @@ Esta guía describe las actividades que el instructor y los/las trainees realiza
    - REP Practical Labs consolida los resultados del laboratorio y envía un resumen automático al Reporting Workspace.
    - El instructor revisa los hallazgos y coordina la retroalimentación grupal destacando aciertos y áreas de mejora.
 
+## Ejercicios avanzados
+
+### Campaña de spear phishing multicanal
+- **Objetivo**: diseñar y ejecutar una campaña que combine correo electrónico, mensajería instantánea y llamadas simuladas para reforzar la detección de tácticas de spear phishing dirigidas.
+- **Pasos clave**:
+  1. En **REP Scheduler**, el instructor programa un bloque adicional que sincroniza los distintos canales y define los criterios de activación para cada grupo de trainees.
+  2. Durante la actividad en **REP Live Session**, se liberan los mensajes según el guion temporal y se monitoriza la respuesta de los/las participantes en los canales colaborativos.
+  3. Los resultados se documentan en **REP Practical Labs**, que registra evidencias de cada canal y permite comparar la eficacia de las contramedidas aplicadas.
+  4. El **Reporting Workspace** consolida los indicadores de cada canal (tasa de clics, respuestas sospechosas, tiempos de reporte) para apoyar la discusión final.
+
+### Cadena de respuesta colaborativa
+- **Objetivo**: entrenar la coordinación entre roles técnicos y no técnicos ante una alerta de phishing escalada en la plataforma.
+- **Pasos clave**:
+  1. El instructor habilita en **REP Scheduler** una práctica secuencial que asigna tareas a cada rol (analista, communications lead, soporte legal) y define los disparadores de escalamiento.
+  2. En **REP Live Session**, los/las trainees trabajan en tiempo real sobre el caso, utilizando los tableros compartidos y el chat para acordar decisiones y documentar acciones.
+  3. **REP Practical Labs** captura los artefactos generados (formularios de notificación, tickets de soporte, análisis de evidencia) y verifica el cumplimiento de los pasos del playbook.
+  4. El **Reporting Workspace** produce un informe de colaboración que destaca los hitos, tiempos de respuesta y dependencias críticas.
+
+### Informe forense exprés
+- **Objetivo**: elaborar un reporte condensado de análisis forense tras la detección de un phishing exitoso, sintetizando evidencias y recomendaciones.
+- **Pasos clave**:
+  1. A través de **REP Scheduler**, se despliega un módulo intensivo que incluye capturas de evidencias, logs y artefactos comprometidos para su revisión.
+  2. En **REP Live Session**, el instructor guía un breve repaso de las evidencias críticas y aclara el alcance del informe que debe entregarse.
+  3. Los/las trainees utilizan **REP Practical Labs** para procesar las evidencias, generar hallazgos preliminares y estructurar las secciones del informe.
+  4. El informe final se carga en el **Reporting Workspace**, donde se valida contra una plantilla de incident response y se comparan las conclusiones entre equipos.
+
 ## Criterios de evaluación
 - Configuración completa del curso en REP Scheduler con todos los materiales obligatorios.
 - Tasa de respuestas correctas en los cuestionarios superior al umbral definido por el instructor.
 - Cobertura del laboratorio: revisión de cabeceras, análisis de indicadores y verificación de adjuntos en los simuladores.
-- Entrega de un reporte final que sintetice riesgos detectados y recomendaciones para mitigar campañas de phishing.
+- Ejecución satisfactoria de los ejercicios avanzados, demostrando coordinación multicanal, colaboración entre roles y capacidad de síntesis forense según las pautas del Reporting Workspace.
+- Entrega de un reporte final que sintetice riesgos detectados, hallazgos de los ejercicios avanzados y recomendaciones para mitigar campañas de phishing.
 
 ## Retroalimentación automática de la plataforma
 - REP Quiz Engine muestra inmediatamente las respuestas correctas e incorrectas, incluyendo la explicación asociada a cada pregunta.
 - REP Practical Labs asigna puntuaciones parciales por cada paso del análisis de correos (identificación del remitente, validación de enlaces y revisión de adjuntos) y genera alertas cuando falta documentar una evidencia.
 - El Reporting Workspace emite un tablero resumen con indicadores de cumplimiento y un semáforo de riesgo por participante, que sirve como base para la retroalimentación personalizada del instructor.
+- Para los ejercicios avanzados, REP Scheduler genera alertas sobre hitos no completados, REP Live Session ofrece registros de participación colaborativa y el Reporting Workspace añade paneles específicos que visualizan tiempos de respuesta, calidad de las entregas forenses y efectividad de la campaña multicanal.


### PR DESCRIPTION
## Summary
- add an "Ejercicios avanzados" section covering multicanal spear phishing, colaboración y reporte forense
- update evaluation criteria and automated feedback notes to reflect the new advanced scenarios

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d111a0a3c0832dbd87688201f38029