### PR TITLE
Translate documentation to British English

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,51 +1,51 @@
-# CyberRangeCZ - Ejercicios prácticos
+# CyberRangeCZ - Practical Exercises
 
-Este repositorio recopila únicamente los materiales necesarios para ejecutar los ejercicios prácticos de la iniciativa **CyberRangeCZ**. No incluye infraestructuras genéricas ni dependencias del laboratorio KYPO; todo el contenido está centrado en los flujos operativos actualmente validados para los subcasos 1a y 1d del diagrama de arquitectura.
+This repository gathers only the materials required to run the practical exercises of the **CyberRangeCZ** initiative. It does not include generic infrastructure or dependencies from the KYPO laboratory; every asset focuses on the operational workflows currently validated for subcases 1a and 1d of the architecture diagram.
 
-## Alcance de los ejercicios
+## Scope of the exercises
 
-- **Subcaso 1a – Entrenamiento guiado por instructor**: describe la dinámica educativa combinando al instructor, la plataforma Random Education Platform (REP) y los/las participantes.
-- **Subcaso 1d – Operación NG-SOC**: documenta cómo los componentes NG-SOC/NG-SIEM y NG-SOAR coordinan la respuesta automatizada apoyándose en el operador CICMS, CTI-SS y la biblioteca de playbooks/estándares (NVD/NIST, MITRE ATT&CK).
+- **Subcase 1a – Instructor-led training**: outlines the educational dynamic involving the instructor, the Random Education Platform (REP) and the participants.
+- **Subcase 1d – NG-SOC operation**: documents how the NG-SOC/NG-SIEM and NG-SOAR components coordinate the automated response with support from the CICMS Operator, CTI-SS and the playbook/standards library (NVD/NIST, MITRE ATT&CK).
 
-A continuación se resume el flujo detallado de cada subcaso para facilitar su reproducción durante las sesiones prácticas.
+The detailed flow for each subcase is summarised below to facilitate reproduction during the practical sessions.
 
-## Flujo del Subcaso 1a
+## Subcase 1a flow
 
-1. **Preparación del instructor**  
-   - El instructor revisa la guía del ejercicio y configura la sesión en la REP con los módulos correspondientes al tema del día.  
-   - Se habilitan las herramientas colaborativas (chat, videoconferencia, pizarra digital) que acompañarán la sesión.
-2. **Sesión en la Random Education Platform (REP)**  
-   - El instructor inicia la transmisión del contenido y comparte los objetivos.  
-   - La REP asigna automáticamente a cada participante un itinerario personalizado combinando teoría breve, escenarios simulados y recordatorios de buenas prácticas.
-3. **Cuestionarios formativos para trainees**  
-   - Los/las trainees completan cuestionarios interactivos en la REP para validar la comprensión inmediata.  
-   - El instructor monitoriza en tiempo real los resultados y ofrece retroalimentación puntual.
-4. **Pruebas prácticas evaluadas**  
-   - La REP genera ejercicios prácticos supervisados (laboratorios virtuales o retos breves).  
-   - Los resultados se registran y se consolidan en un reporte que el instructor revisa con el grupo durante la retroalimentación final.
+1. **Instructor preparation**
+   - The instructor reviews the exercise guide and configures the session in the REP with the modules that match the topic of the day.
+   - Collaborative tools (chat, videoconferencing, digital whiteboard) that accompany the session are enabled.
+2. **Session on the Random Education Platform (REP)**
+   - The instructor starts broadcasting the content and shares the objectives.
+   - The REP automatically assigns each participant a personalised itinerary that combines short theory, simulated scenarios and reminders of good practice.
+3. **Formative quizzes for trainees**
+   - Trainees complete interactive quizzes in the REP to validate immediate understanding.
+   - The instructor monitors the results in real time and provides targeted feedback.
+4. **Assessed practical tests**
+   - The REP generates supervised practical exercises (virtual labs or short challenges).
+   - The results are recorded and consolidated into a report that the instructor reviews with the group during the final feedback.
 
-## Flujo del Subcaso 1d
+## Subcase 1d flow
 
-1. **Detección en NG-SOC/NG-SIEM**  
-   - NG-SIEM recibe eventos desde las fuentes de telemetría del CyberRangeCZ y genera alertas priorizadas.  
-   - El analista de NG-SOC valida la alerta y selecciona el playbook CACAO pertinente.
-2. **Orquestación de playbooks CACAO**  
-   - El orquestador NG-SOC invoca el NG-SOAR para ejecutar el playbook seleccionado.  
-   - NG-SOAR coordina tareas automáticas (enriquecimiento, contención y notificación) respetando la secuencia definida en CACAO.
-3. **Apoyo de sistemas transversales**
-   - **CICMS Operator** centraliza la documentación del incidente y canaliza los reportes posteriores.
-   - **CTI-SS** aporta inteligencia de amenazas y contexto adicional para la toma de decisiones.
-   - **Biblioteca de playbooks y estándares (NVD/NIST, MITRE ATT&CK)** guía la selección de acciones de respuesta y recuperación.
-4. **Cierre y retroalimentación**
-   - NG-SOAR consolida los resultados y devuelve el estado final a NG-SOC/NG-SIEM.
-   - CICMS Operator genera el reporte post-incidente y referencia las lecciones aprendidas en la biblioteca de playbooks.
+1. **Detection in NG-SOC/NG-SIEM**
+   - NG-SIEM receives events from CyberRangeCZ telemetry sources and raises prioritised alerts.
+   - The NG-SOC analyst validates the alert and selects the relevant CACAO playbook.
+2. **CACAO playbook orchestration**
+   - The NG-SOC orchestrator invokes NG-SOAR to run the chosen playbook.
+   - NG-SOAR coordinates automated tasks (enrichment, containment and notification) following the CACAO sequence.
+3. **Support from transversal systems**
+   - **CICMS Operator** centralises incident documentation and channels post-incident reports.
+   - **CTI-SS** provides threat intelligence and additional context for decision-making.
+   - **Playbook and standards library (NVD/NIST, MITRE ATT&CK)** guides the selection of response and recovery actions.
+4. **Closure and feedback**
+   - NG-SOAR consolidates the outcomes and returns the final status to NG-SOC/NG-SIEM.
+   - CICMS Operator produces the post-incident report and references lessons learnt in the playbook library.
 
-## Archivos principales
+## Key files
 
-- `training_linear.json`: lista los módulos de aprendizaje de los subcasos 1a y 1d, con actividades paso a paso y herramientas implicadas.
-- `topology.yml`: describe los componentes del CyberRangeCZ relevantes para los ejercicios y su integración con las herramientas educativas y operativas.
-- `docs/`: materiales de apoyo y guías complementarias.
+- `training_linear.json`: lists the learning modules for subcases 1a and 1d, including step-by-step activities and the tools involved.
+- `topology.yml`: describes the CyberRangeCZ components relevant to the exercises and how they integrate with the educational and operational tooling.
+- `docs/`: support materials and complementary guides.
 
-## Licencia
+## Licence
 
-El contenido se entrega con fines estrictamente educativos dentro del marco de CyberRangeCZ.
+The content is provided strictly for educational purposes within the CyberRangeCZ framework.

--- a/docs/subcase-1a-phishing-awareness.md
+++ b/docs/subcase-1a-phishing-awareness.md
@@ -1,61 +1,61 @@
-# Subcaso 1a – Phishing Awareness en la Random Education Platform
+# Subcase 1a – Phishing Awareness on the Random Education Platform
 
-Esta guía describe las actividades que el instructor y los/las trainees realizan dentro de la Random Education Platform (REP) para el módulo de concienciación frente a phishing. El flujo mantiene la correspondencia con los componentes documentados en la arquitectura de CyberRangeCZ.
+This guide describes the activities carried out by the instructor and trainees within the Random Education Platform (REP) for the phishing awareness module. The flow mirrors the components documented in the CyberRangeCZ architecture.
 
-## Preparación del curso por el instructor
-- **Planificación en la consola del instructor**: se definen los objetivos del módulo y se asignan los recursos necesarios desde el repositorio de contenidos de CyberRangeCZ.
-- **Programación en REP Scheduler**: el instructor crea el curso temático y activa los bloques de teoría, ejercicios guiados y prácticas sobre análisis de correos sospechosos.
-- **Sincronización con el Reporting Workspace**: se configuran los tableros de métricas que recibirán los resultados de cuestionarios y laboratorios.
+## Course preparation by the instructor
+- **Planning in the instructor console**: define the module objectives and assign the necessary resources from the CyberRangeCZ content repository.
+- **Scheduling in REP Scheduler**: the instructor creates the themed course and enables the theory blocks, guided exercises and practical work on suspicious email analysis.
+- **Synchronisation with the Reporting Workspace**: configure the metric dashboards that will receive the quiz and lab results.
 
-## Desarrollo de la sesión
-1. **Apertura en REP Live Session**
-   - El instructor inicia la sesión en vivo, comparte las reglas del ejercicio y habilita los canales colaborativos integrados (chat, videoconferencia y pizarra).
-   - Las estaciones de trabajo de los/las trainees reciben el itinerario personalizado con cápsulas teóricas y recordatorios de buenas prácticas.
-2. **Cuestionarios en REP Quiz Engine**
-   - Cada trainee responde cuestionarios formativos que evalúan conceptos clave de phishing.
-   - El panel analítico muestra puntuaciones en tiempo real para orientar la intervención del instructor.
-3. **Laboratorio de análisis de correos**
-   - A través de los simuladores del CyberRangeCZ, los/las trainees clasifican correos potencialmente maliciosos, verifican cabeceras y adjuntos en un entorno controlado.
-   - Las acciones se registran y se vinculan con los objetivos del curso para su evaluación posterior.
-4. **Cierre y reporte**
-   - REP Practical Labs consolida los resultados del laboratorio y envía un resumen automático al Reporting Workspace.
-   - El instructor revisa los hallazgos y coordina la retroalimentación grupal destacando aciertos y áreas de mejora.
+## Session delivery
+1. **Opening in REP Live Session**
+   - The instructor starts the live session, shares the exercise rules and enables the integrated collaborative channels (chat, videoconferencing and whiteboard).
+   - The trainees' workstations receive a personalised itinerary with theory capsules and reminders of good practice.
+2. **Quizzes in REP Quiz Engine**
+   - Each trainee answers formative quizzes that assess key phishing concepts.
+   - The analytics panel displays scores in real time to guide the instructor's intervention.
+3. **Email analysis lab**
+   - Through the CyberRangeCZ simulators, trainees classify potentially malicious emails, verify headers and inspect attachments in a controlled environment.
+   - The actions are recorded and linked to the course objectives for later assessment.
+4. **Closure and reporting**
+   - REP Practical Labs consolidates the lab results and sends an automatic summary to the Reporting Workspace.
+   - The instructor reviews the findings and leads group feedback, highlighting strengths and improvement areas.
 
-## Ejercicios avanzados
+## Advanced exercises
 
-### Campaña de spear phishing multicanal
-- **Objetivo**: diseñar y ejecutar una campaña que combine correo electrónico, mensajería instantánea y llamadas simuladas para reforzar la detección de tácticas de spear phishing dirigidas.
-- **Pasos clave**:
-  1. En **REP Scheduler**, el instructor programa un bloque adicional que sincroniza los distintos canales y define los criterios de activación para cada grupo de trainees.
-  2. Durante la actividad en **REP Live Session**, se liberan los mensajes según el guion temporal y se monitoriza la respuesta de los/las participantes en los canales colaborativos.
-  3. Los resultados se documentan en **REP Practical Labs**, que registra evidencias de cada canal y permite comparar la eficacia de las contramedidas aplicadas.
-  4. El **Reporting Workspace** consolida los indicadores de cada canal (tasa de clics, respuestas sospechosas, tiempos de reporte) para apoyar la discusión final.
+### Multi-channel spear phishing campaign
+- **Objective**: design and run a campaign combining email, instant messaging and simulated calls to reinforce the detection of targeted spear phishing tactics.
+- **Key steps**:
+  1. In **REP Scheduler**, the instructor programmes an additional block that synchronises the different channels and defines activation criteria for each trainee group.
+  2. During the activity in **REP Live Session**, messages are released according to the planned timeline and participants' responses across collaborative channels are monitored.
+  3. The outcomes are documented in **REP Practical Labs**, which records evidence for each channel and enables comparison of the effectiveness of the applied countermeasures.
+  4. The **Reporting Workspace** consolidates indicators for each channel (click rate, suspicious responses, reporting times) to support the final debrief.
 
-### Cadena de respuesta colaborativa
-- **Objetivo**: entrenar la coordinación entre roles técnicos y no técnicos ante una alerta de phishing escalada en la plataforma.
-- **Pasos clave**:
-  1. El instructor habilita en **REP Scheduler** una práctica secuencial que asigna tareas a cada rol (analista, communications lead, soporte legal) y define los disparadores de escalamiento.
-  2. En **REP Live Session**, los/las trainees trabajan en tiempo real sobre el caso, utilizando los tableros compartidos y el chat para acordar decisiones y documentar acciones.
-  3. **REP Practical Labs** captura los artefactos generados (formularios de notificación, tickets de soporte, análisis de evidencia) y verifica el cumplimiento de los pasos del playbook.
-  4. El **Reporting Workspace** produce un informe de colaboración que destaca los hitos, tiempos de respuesta y dependencias críticas.
+### Collaborative response chain
+- **Objective**: train the coordination between technical and non-technical roles when a phishing alert is escalated on the platform.
+- **Key steps**:
+  1. The instructor enables in **REP Scheduler** a sequential exercise that assigns tasks to each role (analyst, communications lead, legal support) and defines escalation triggers.
+  2. In **REP Live Session**, trainees work in real time on the case, using shared dashboards and chat to agree decisions and document actions.
+  3. **REP Practical Labs** captures the generated artefacts (notification forms, support tickets, evidence analysis) and checks compliance with the playbook steps.
+  4. The **Reporting Workspace** produces a collaboration report highlighting milestones, response times and critical dependencies.
 
-### Informe forense exprés
-- **Objetivo**: elaborar un reporte condensado de análisis forense tras la detección de un phishing exitoso, sintetizando evidencias y recomendaciones.
-- **Pasos clave**:
-  1. A través de **REP Scheduler**, se despliega un módulo intensivo que incluye capturas de evidencias, logs y artefactos comprometidos para su revisión.
-  2. En **REP Live Session**, el instructor guía un breve repaso de las evidencias críticas y aclara el alcance del informe que debe entregarse.
-  3. Los/las trainees utilizan **REP Practical Labs** para procesar las evidencias, generar hallazgos preliminares y estructurar las secciones del informe.
-  4. El informe final se carga en el **Reporting Workspace**, donde se valida contra una plantilla de incident response y se comparan las conclusiones entre equipos.
+### Express forensic report
+- **Objective**: produce a concise forensic report after detecting a successful phishing attempt, summarising evidence and recommendations.
+- **Key steps**:
+  1. Via **REP Scheduler**, an intensive module is deployed including captured evidence, logs and compromised artefacts for review.
+  2. In **REP Live Session**, the instructor leads a brief review of the critical evidence and clarifies the scope of the report to be delivered.
+  3. Trainees use **REP Practical Labs** to process the evidence, generate preliminary findings and structure the report sections.
+  4. The final report is uploaded to the **Reporting Workspace**, where it is validated against an incident response template and the conclusions are compared across teams.
 
-## Criterios de evaluación
-- Configuración completa del curso en REP Scheduler con todos los materiales obligatorios.
-- Tasa de respuestas correctas en los cuestionarios superior al umbral definido por el instructor.
-- Cobertura del laboratorio: revisión de cabeceras, análisis de indicadores y verificación de adjuntos en los simuladores.
-- Ejecución satisfactoria de los ejercicios avanzados, demostrando coordinación multicanal, colaboración entre roles y capacidad de síntesis forense según las pautas del Reporting Workspace.
-- Entrega de un reporte final que sintetice riesgos detectados, hallazgos de los ejercicios avanzados y recomendaciones para mitigar campañas de phishing.
+## Assessment criteria
+- Complete configuration of the course in REP Scheduler with all mandatory materials.
+- Quiz pass rate above the threshold defined by the instructor.
+- Lab coverage: header review, indicator analysis and attachment inspection within the simulators.
+- Successful delivery of the advanced exercises, demonstrating multi-channel coordination, cross-role collaboration and forensic synthesis according to the Reporting Workspace guidelines.
+- Submission of a final report summarising detected risks, findings from the advanced exercises and recommendations to mitigate phishing campaigns.
 
-## Retroalimentación automática de la plataforma
-- REP Quiz Engine muestra inmediatamente las respuestas correctas e incorrectas, incluyendo la explicación asociada a cada pregunta.
-- REP Practical Labs asigna puntuaciones parciales por cada paso del análisis de correos (identificación del remitente, validación de enlaces y revisión de adjuntos) y genera alertas cuando falta documentar una evidencia.
-- El Reporting Workspace emite un tablero resumen con indicadores de cumplimiento y un semáforo de riesgo por participante, que sirve como base para la retroalimentación personalizada del instructor.
-- Para los ejercicios avanzados, REP Scheduler genera alertas sobre hitos no completados, REP Live Session ofrece registros de participación colaborativa y el Reporting Workspace añade paneles específicos que visualizan tiempos de respuesta, calidad de las entregas forenses y efectividad de la campaña multicanal.
+## Automatic platform feedback
+- REP Quiz Engine immediately shows correct and incorrect answers, including the explanation associated with each question.
+- REP Practical Labs awards partial scores for every email analysis step (identifying the sender, validating links and reviewing attachments) and raises alerts when evidence has not been documented.
+- The Reporting Workspace issues a summary dashboard with compliance indicators and a traffic-light risk status per participant, providing a basis for the instructor's personalised feedback.
+- For the advanced exercises, REP Scheduler generates alerts about incomplete milestones, REP Live Session offers records of collaborative participation, and the Reporting Workspace adds dedicated panels that display response times, the quality of forensic deliverables and the effectiveness of the multi-channel campaign.

--- a/docs/subcase-1d-playbook-automation.md
+++ b/docs/subcase-1d-playbook-automation.md
@@ -1,63 +1,63 @@
-# Subcaso 1d – Automatización de Playbooks en el ecosistema NG-SOC
+# Subcase 1d – Playbook Automation in the NG-SOC Ecosystem
 
-Este documento resume las actividades que se desarrollan en el entorno operativo integrado por NG-SOC, NG-SIEM, NG-SOAR, el operador CICMS, CTI-SS y la biblioteca de playbooks/estándares (NVD/NIST, MITRE ATT&CK) durante la ejecución del subcaso 1d.
+This document summarises the activities carried out in the operational environment formed by NG-SOC, NG-SIEM, NG-SOAR, the CICMS Operator, CTI-SS and the playbook/standards library (NVD/NIST, MITRE ATT&CK) during the execution of subcase 1d.
 
-## Flujo operativo
-1. **Generación de alerta en NG-SIEM**
-   - NG-SIEM correlaciona eventos de telemetría y produce una alerta priorizada que incluye indicadores clave y activos afectados.
-   - La alerta se envía a la consola de NG-SOC junto con las recomendaciones iniciales basadas en reglas de correlación.
-2. **Validación en NG-SOC**
-   - El analista revisa la alerta, selecciona el playbook CACAO adecuado desde el repositorio de NG-SOC y define los parámetros de ejecución.
-   - Se contrasta la selección con la biblioteca de playbooks/estándares para asegurar cobertura frente a MITRE ATT&CK y referencias NVD/NIST.
-3. **Orquestación mediante NG-SOAR**
-   - NG-SOC orquesta la ejecución delegando en NG-SOAR, que interpreta la secuencia CACAO y coordina tareas automáticas.
-   - Los conectores de NG-SOAR consultan CTI-SS para enriquecer indicadores y validar reputación.
-4. **Coordinación con CICMS Operator**
-   - Cuando el playbook requiere intervenciones manuales o validaciones, NG-SOAR sincroniza los hitos con el operador CICMS.
-   - CICMS Operator consolida evidencias, actualiza el estado del incidente y prepara el reporte post-incidente.
-5. **Documentación y aprendizaje con la biblioteca de playbooks**
-   - Al finalizar cada fase, NG-SOAR publica los resultados en NG-SOC y NG-SIEM, mientras que CICMS Operator anota las decisiones relevantes.
-   - Se actualizan las referencias de la biblioteca (MITRE ATT&CK, NVD/NIST) con lecciones aprendidas y enlaces a CTI reciente.
+## Operational flow
+1. **Alert generation in NG-SIEM**
+   - NG-SIEM correlates telemetry events and produces a prioritised alert that includes key indicators and affected assets.
+   - The alert is sent to the NG-SOC console together with the initial recommendations based on correlation rules.
+2. **Validation in NG-SOC**
+   - The analyst reviews the alert, selects the appropriate CACAO playbook from the NG-SOC repository and defines the execution parameters.
+   - The selection is checked against the playbook/standards library to ensure coverage of MITRE ATT&CK and NVD/NIST references.
+3. **Orchestration via NG-SOAR**
+   - NG-SOC orchestrates the execution by delegating to NG-SOAR, which interprets the CACAO sequence and coordinates automated tasks.
+   - NG-SOAR connectors consult CTI-SS to enrich indicators and validate reputation.
+4. **Coordination with CICMS Operator**
+   - When the playbook requires manual interventions or validations, NG-SOAR synchronises the milestones with the CICMS operator.
+   - CICMS Operator consolidates evidence, updates the incident status and prepares the post-incident report.
+5. **Documentation and learning with the playbook library**
+   - At the end of each phase, NG-SOAR publishes the results in NG-SOC and NG-SIEM, while CICMS Operator records relevant decisions.
+   - References in the library (MITRE ATT&CK, NVD/NIST) are updated with lessons learnt and links to recent CTI.
 
-## Ejercicios prácticos
-### Ejercicio 1: Ransomware en infraestructura crítica
-- **Objetivo:** validar la detección temprana y la contención automática de un ataque de cifrado masivo.
-- **Fases operativas:**
-  1. *Detección*: NG-SIEM identifica patrones de cifrado anómalos y genera la alerta priorizada.
-  2. *Contención*: NG-SOAR ejecuta el playbook CACAO para aislar los endpoints críticos y revocar credenciales sospechosas.
-  3. *Recuperación*: CICMS coordina con los equipos de continuidad para restaurar respaldos y verificar integridad.
-- **Interacción de plataformas:** NG-SIEM alimenta a NG-SOAR con artefactos para automatizar la respuesta; NG-SOAR invoca conectores resilientes hacia CTI-SS para validar indicadores y hacia la biblioteca de playbooks para confirmar la cobertura MITRE ATT&CK; CICMS documenta las decisiones y actualiza el estado de recuperación, mientras NG-SOC supervisa la ejecución de extremo a extremo.
+## Practical exercises
+### Exercise 1: Ransomware in critical infrastructure
+- **Objective:** validate early detection and automatic containment of a mass encryption attack.
+- **Operational phases:**
+  1. *Detection*: NG-SIEM identifies anomalous encryption patterns and raises the prioritised alert.
+  2. *Containment*: NG-SOAR runs the CACAO playbook to isolate critical endpoints and revoke suspicious credentials.
+  3. *Recovery*: CICMS coordinates with continuity teams to restore backups and verify integrity.
+- **Platform interaction:** NG-SIEM feeds NG-SOAR with artefacts to automate the response; NG-SOAR invokes resilient connectors towards CTI-SS to validate indicators and towards the playbook library to confirm MITRE ATT&CK coverage; CICMS documents decisions and updates the recovery status, while NG-SOC supervises the end-to-end execution.
 
-### Ejercicio 2: Exfiltración de datos mediante canal cifrado
-- **Objetivo:** asegurar que el ecosistema coordine la investigación y bloqueo de comunicaciones maliciosas hacia servicios externos.
-- **Fases operativas:**
-  1. *Correlación*: NG-SIEM cruza flujos de red con inteligencia CTI-SS para identificar direcciones de comando y control.
-  2. *Orquestación*: NG-SOC selecciona el playbook CACAO que instruye a NG-SOAR para desplegar reglas de firewall y solicitar evidencia a herramientas de DLP.
-  3. *Análisis y cierre*: CICMS centraliza la evidencia, mientras la biblioteca de playbooks almacena los indicadores para futuras referencias.
-- **Interacción de plataformas:** NG-SOAR mantiene conectores redundantes hacia dispositivos de red para garantizar la aplicación de bloqueos; CTI-SS aporta indicadores enriquecidos; CICMS registra las aprobaciones y el racional técnico, y NG-SOC ajusta la estrategia basándose en los informes provenientes de NG-SIEM y NG-SOAR.
+### Exercise 2: Data exfiltration through encrypted channel
+- **Objective:** ensure the ecosystem coordinates the investigation and blocking of malicious communications to external services.
+- **Operational phases:**
+  1. *Correlation*: NG-SIEM cross-references network flows with CTI-SS intelligence to identify command-and-control addresses.
+  2. *Orchestration*: NG-SOC selects the CACAO playbook that instructs NG-SOAR to deploy firewall rules and request evidence from DLP tools.
+  3. *Analysis and closure*: CICMS centralises the evidence, while the playbook library stores the indicators for future reference.
+- **Platform interaction:** NG-SOAR maintains redundant connectors towards network devices to guarantee enforcement of the blocks; CTI-SS provides enriched indicators; CICMS records approvals and the technical rationale, and NG-SOC adjusts the strategy based on the reports from NG-SIEM and NG-SOAR.
 
-### Ejercicio 3: Compromiso de credenciales privilegiadas
-- **Objetivo:** evaluar la capacidad de detección, respuesta y remediación de accesos privilegiados comprometidos.
-- **Fases operativas:**
-  1. *Alerta inicial*: NG-SIEM detecta actividad sospechosa en cuentas privilegiadas con base en anomalías de comportamiento.
-  2. *Respuesta coordinada*: NG-SOC selecciona un playbook de rotación de credenciales que NG-SOAR ejecuta para revocar accesos, generar credenciales temporales y notificar a los responsables.
-  3. *Verificación y lecciones*: CICMS valida que se restablecieron los controles, mientras la biblioteca de playbooks incorpora las mejoras y CTI-SS añade firmas relacionadas.
-- **Interacción de plataformas:** NG-SOAR asegura la resiliencia de los conectores hacia los sistemas de gestión de identidades; NG-SIEM monitorea los eventos posteriores a la rotación; CICMS actualiza la documentación y las métricas de impacto, y NG-SOC utiliza la biblioteca de playbooks para proponer ajustes estratégicos y generar entrenamiento adicional.
+### Exercise 3: Compromise of privileged credentials
+- **Objective:** assess the capability to detect, respond to and remediate compromised privileged access.
+- **Operational phases:**
+  1. *Initial alert*: NG-SIEM detects suspicious activity on privileged accounts based on behavioural anomalies.
+  2. *Co-ordinated response*: NG-SOC selects a credential rotation playbook that NG-SOAR runs to revoke access, generate temporary credentials and notify those responsible.
+  3. *Verification and lessons*: CICMS confirms that controls have been reinstated, while the playbook library incorporates the improvements and CTI-SS adds related signatures.
+- **Platform interaction:** NG-SOAR ensures the resilience of connectors to identity management systems; NG-SIEM monitors events after the rotation; CICMS updates the documentation and impact metrics, and NG-SOC uses the playbook library to propose strategic adjustments and produce additional training.
 
-## Criterios de evaluación
-- Selección correcta del playbook CACAO en NG-SOC acorde a la clasificación inicial de la alerta.
-- Ejecución completa de las acciones automatizadas en NG-SOAR sin fallos en los conectores críticos.
-- Sincronización oportuna de los hitos en CICMS Operator, incluyendo evidencias y aprobaciones requeridas.
-- Registro de las lecciones aprendidas en la biblioteca de playbooks, enlazando controles MITRE ATT&CK y referencias NVD/NIST aplicadas.
-- Resiliencia de los conectores orquestados por NG-SOAR y NG-SOC, validando redundancias y planes de contingencia documentados.
-- Documentación exhaustiva en CICMS Operator, incluyendo procedimientos seguidos, indicadores finales y responsables de cada acción.
-- Incorporación y seguimiento de métricas post-incidente (tiempo de contención, tiempo de recuperación, impacto residual) registradas en NG-SIEM, NG-SOAR y CICMS.
+## Assessment criteria
+- Correct selection of the CACAO playbook in NG-SOC according to the alert's initial classification.
+- Complete execution of the automated actions in NG-SOAR without failures in critical connectors.
+- Timely synchronisation of milestones in CICMS Operator, including required evidence and approvals.
+- Recording of lessons learnt in the playbook library, linking applied MITRE ATT&CK controls and NVD/NIST references.
+- Resilience of the connectors orchestrated by NG-SOAR and NG-SOC, validating redundancies and documented contingency plans.
+- Comprehensive documentation in CICMS Operator, including procedures followed, final indicators and the person responsible for each action.
+- Incorporation and monitoring of post-incident metrics (containment time, recovery time, residual impact) recorded in NG-SIEM, NG-SOAR and CICMS.
 
-## Retroalimentación automática de la plataforma
-- NG-SIEM genera un puntaje de calidad de detección basado en la precisión de la correlación y lo muestra en la consola de NG-SOC.
-- NG-SOAR expone un informe de ejecución del playbook con métricas de éxito por tarea, destacando los pasos que requieren revisión.
-- CICMS Operator alerta cuando un hito manual queda pendiente y conserva la trazabilidad necesaria para auditoría.
-- La biblioteca de playbooks publica un resumen actualizado con referencias a MITRE ATT&CK, NVD/NIST y CTI reciente para incidentes futuros.
-- Los conectores monitoreados por NG-SOAR reportan indicadores de resiliencia (latencia, disponibilidad, reintentos) para facilitar ajustes preventivos.
-- CICMS Operator genera recordatorios automáticos para completar la documentación pendiente y contrastarla con los lineamientos internos.
-- Se calculan métricas post-incidente consolidadas (MTTD, MTTR, eficacia de contención) y se comparan con umbrales definidos dentro de la biblioteca de playbooks.
+## Automatic platform feedback
+- NG-SIEM generates a detection quality score based on correlation accuracy and displays it on the NG-SOC console.
+- NG-SOAR provides a playbook execution report with success metrics per task, highlighting the steps that require review.
+- CICMS Operator issues alerts when a manual milestone remains pending and preserves the traceability required for audit.
+- The playbook library publishes an updated summary with references to MITRE ATT&CK, NVD/NIST and recent CTI for future incidents.
+- Connectors monitored by NG-SOAR report resilience indicators (latency, availability, retries) to support preventive adjustments.
+- CICMS Operator generates automatic reminders to complete pending documentation and compare it with internal guidelines.
+- Consolidated post-incident metrics (MTTD, MTTR, containment effectiveness) are calculated and compared with thresholds defined within the playbook library.

--- a/provisioning/README.md
+++ b/provisioning/README.md
@@ -1,8 +1,8 @@
-# Artefactos de habilitación para CyberRangeCZ
+# Enablement artefacts for CyberRangeCZ
 
-Este directorio ya no contiene playbooks de aprovisionamiento. En su lugar alberga artefactos de referencia para habilitar la Random Education Platform (REP) y los servicios NG-SOC/NG-SIEM/NG-SOAR/CICMS Operator/CTI-SS/Biblioteca de playbooks descritos en el Subcaso 1d.
+This directory no longer contains provisioning playbooks. Instead, it hosts reference artefacts that enable the Random Education Platform (REP) and the NG-SOC/NG-SIEM/NG-SOAR/CICMS Operator/CTI-SS/Playbook Library services described in Subcase 1d.
 
-- `subcase-1d-services.md` documenta cómo activar y relacionar cada componente.
-- `cacao-playbook-automation.md` describe los procedimientos automatizados para la gestión del ciclo de vida de playbooks CACAO dentro de NG-SOAR y su integración con CICMS Operator, CTI-SS y la biblioteca de playbooks.
+- `subcase-1d-services.md` documents how to activate and connect each component.
+- `cacao-playbook-automation.md` sets out the automated procedures for managing the CACAO playbook lifecycle within NG-SOAR and its integration with CICMS Operator, CTI-SS and the playbook library.
 
-Cada artefacto se centra exclusivamente en las capacidades mostradas en el diagrama de subcasos y omite dependencias con herramientas externas ajenas al ecosistema NG.
+Each artefact focuses exclusively on the capabilities shown in the subcase diagram and omits dependencies on external tooling unrelated to the NG ecosystem.

--- a/provisioning/cacao-playbook-automation.md
+++ b/provisioning/cacao-playbook-automation.md
@@ -1,15 +1,15 @@
-# Procedimientos automatizados para playbooks CACAO en NG-SOAR
+# Automated procedures for CACAO playbooks in NG-SOAR
 
-Este documento reemplaza los scripts de despliegue tradicionales y describe cómo automatizar el ciclo de vida de los playbooks CACAO dentro de NG-SOAR, garantizando su sincronización con CICMS Operator, CTI-SS y la biblioteca de playbooks. Las automatizaciones se basan en API disponibles en los componentes del Subcaso 1d y pueden ejecutarse desde cualquier consola con acceso autenticado.
+This document replaces traditional deployment scripts and explains how to automate the lifecycle of CACAO playbooks within NG-SOAR, ensuring synchronisation with CICMS Operator, CTI-SS and the playbook library. The automations rely on APIs available in the Subcase 1d components and can be run from any console with authenticated access.
 
-> **Requisitos previos:** los ejemplos utilizan [HTTPie](https://httpie.io/) con las opciones `--check-status` y `--print=b` (`-b`) para asegurarse de que cualquier procesamiento posterior, como `jq`, opere exclusivamente sobre el cuerpo JSON devuelto por la API y para que los scripts fallen ante códigos HTTP no exitosos.
+> **Prerequisites:** the examples use [HTTPie](https://httpie.io/) with the `--check-status` and `--print=b` (`-b`) options to ensure that any post-processing, such as `jq`, operates solely on the JSON body returned by the API and so that scripts fail on unsuccessful HTTP codes.
 
-## 1. Creación de playbooks
+## 1. Playbook creation
 
 ```bash
 #!/usr/bin/env bash
 # crear_playbook.sh
-# Uso: ./crear_playbook.sh ruta/al/playbook.json
+# Usage: ./crear_playbook.sh path/to/playbook.json
 set -euo pipefail
 PLAYBOOK_PATH="$1"
 TOKEN=$(http --check-status --print=b POST https://ng-soc.example/api/auth username=$SOC_USER password=$SOC_PASS | jq -r '.token')
@@ -27,17 +27,17 @@ http --check-status POST https://cicms.example/api/incidents/register-playbook \
   playbook_path="$PLAYBOOK_PATH"
 ```
 
-- La primera llamada registra el playbook en el repositorio central de NG-SOC.
-- La segunda llamada lo importa en NG-SOAR para quedar disponible en las colas de ejecución.
-- La tercera registra el material en CICMS Operator para que el equipo operativo disponga del contexto actualizado.
-- Cada script de creación debe almacenarse junto con las referencias correspondientes en la biblioteca de playbooks.
+- The first call registers the playbook in the NG-SOC central repository.
+- The second call imports it into NG-SOAR so it is available in the execution queues.
+- The third records the material in CICMS Operator so the operations team has the latest context.
+- Each creation script should be stored together with the corresponding references in the playbook library.
 
-## 2. Actualización y versionado
+## 2. Updating and versioning
 
 ```bash
 #!/usr/bin/env bash
 # actualizar_playbook.sh
-# Uso: ./actualizar_playbook.sh identificador ruta/al/playbook.json
+# Usage: ./actualizar_playbook.sh identifier path/to/playbook.json
 set -euo pipefail
 PLAYBOOK_ID="$1"
 PLAYBOOK_PATH="$2"
@@ -58,15 +58,15 @@ http --check-status POST https://playbooks.example/api/library/register \
   references="MITRE ATT&CK,NVD,NIST"
 ```
 
-- La actualización sincroniza NG-SOC y NG-SOAR con la nueva versión y registra el cambio en la biblioteca de playbooks.
-- La biblioteca conserva el historial de versiones y las notas de publicación.
+- The update synchronises NG-SOC and NG-SOAR with the new version and records the change in the playbook library.
+- The library keeps the version history and the release notes.
 
-## 3. Distribución y compartición con CTI-SS
+## 3. Distribution and sharing with CTI-SS
 
 ```bash
 #!/usr/bin/env bash
 # compartir_playbook.sh
-# Uso: ./compartir_playbook.sh identificador canal_ctiss
+# Usage: ./compartir_playbook.sh identifier ctiss_channel
 set -euo pipefail
 PLAYBOOK_ID="$1"
 CHANNEL="$2"
@@ -81,16 +81,16 @@ http --check-status POST https://cti-ss.example/api/cacao/share \
   payload="$PAYLOAD"
 ```
 
-- NG-SOAR expone el playbook en formato CACAO y CTI-SS lo replica hacia los canales de inteligencia específicos.
-- CTI-SS añade etiquetas y taxonomías antes de redistribuir el contenido.
-- El proceso queda registrado en CICMS Operator y en la biblioteca para mantener la trazabilidad.
+- NG-SOAR exposes the playbook in CACAO format and CTI-SS replicates it to the targeted intelligence channels.
+- CTI-SS adds tags and taxonomies before redistributing the content.
+- The process is logged in CICMS Operator and in the library to maintain traceability.
 
-## 4. Integraciones con CICMS Operator y la biblioteca de playbooks
-- Cada script registra metadatos en CICMS Operator y en la biblioteca (`/library/register`) para mantener la trazabilidad.
-- Los responsables de NG-SOC revisan semanalmente el tablero de CICMS Operator para validar que no existan discrepancias entre versiones.
-- Cuando un playbook alcanza estado estable, se crea un resumen en la biblioteca con referencia a las fuentes de CTI-SS empleadas.
+## 4. Integrations with CICMS Operator and the playbook library
+- Each script records metadata in CICMS Operator and in the library (`/library/register`) to preserve traceability.
+- NG-SOC leads review of the CICMS Operator dashboard every week to confirm there are no discrepancies between versions.
+- When a playbook reaches a stable state, a summary is created in the library with references to the CTI-SS sources used.
 
-## 5. Sustitución de la infraestructura KYPO
-- Estas automatizaciones se ejecutan dentro del propio ecosistema NG y eliminan la dependencia de la infraestructura KYPO.
-- No se requieren máquinas externas ni despliegues adicionales: basta con credenciales de servicio y conectividad segura.
-- La documentación y scripts se alojan en la biblioteca de playbooks asociada al Subcaso 1d.
+## 5. Replacement of the KYPO infrastructure
+- These automations run within the NG ecosystem itself and remove the dependency on the KYPO infrastructure.
+- No external machines or additional deployments are required: service credentials and secure connectivity are sufficient.
+- Documentation and scripts are hosted in the playbook library associated with Subcase 1d.

--- a/provisioning/subcase-1d-services.md
+++ b/provisioning/subcase-1d-services.md
@@ -1,43 +1,43 @@
-# Habilitación de la Random Education Platform y servicios NG del Subcaso 1d
+# Enabling the Random Education Platform and NG services for Subcase 1d
 
-Este artefacto describe las actividades necesarias para disponer de la Random Education Platform (REP) y de los servicios NG-SOC, NG-SIEM, NG-SOAR, CICMS Operator, CTI-SS y la biblioteca de playbooks durante las prácticas del Subcaso 1d. La información se presenta como procedimientos de activación y no como instrucciones de despliegue desde cero; se asume que los componentes existen en el CyberRangeCZ y requieren únicamente configuración y conexión.
+This artefact describes the activities required to make the Random Education Platform (REP) and the NG-SOC, NG-SIEM, NG-SOAR, CICMS Operator, CTI-SS and playbook library services available during the Subcase 1d exercises. The information is presented as activation procedures rather than instructions for deploying from scratch; it assumes the components already exist in CyberRangeCZ and only require configuration and interconnection.
 
 ## Random Education Platform (REP)
-1. **Verificar módulos activos**: habilitar *Scheduler*, *Live Session*, *Quiz Engine* y *Practical Labs* desde el panel de administración.
-2. **Conectar con el instructor**: vincular la consola del instructor y la zona de reporting seleccionando la clase correspondiente en el calendario.
-3. **Sincronizar simuladores**: confirmar que los simuladores de CyberRangeCZ estén publicados como laboratorios dentro de la REP y asignarlos al itinerario del ejercicio.
+1. **Verify active modules**: enable *Scheduler*, *Live Session*, *Quiz Engine* and *Practical Labs* from the administration panel.
+2. **Connect with the instructor**: link the instructor console and the reporting area by selecting the relevant class in the calendar.
+3. **Synchronise simulators**: confirm that the CyberRangeCZ simulators are published as labs within the REP and assign them to the exercise itinerary.
 
 ## NG-SOC
-1. **Activar la recepción de alertas** desde NG-SIEM habilitando el canal seguro `soc-siem`.
-2. **Sincronizar playbooks CACAO** con NG-SOAR mediante la API `soar-repository/sync` para garantizar que las versiones validadas estén disponibles.
-3. **Exponer panel operativo** enlazando la biblioteca de playbooks como fuente de conocimiento para consultas en tiempo real.
+1. **Activate alert reception** from NG-SIEM by enabling the secure `soc-siem` channel.
+2. **Synchronise CACAO playbooks** with NG-SOAR via the `soar-repository/sync` API to ensure validated versions are available.
+3. **Expose the operational dashboard** by linking the playbook library as a knowledge source for real-time queries.
 
 ## NG-SIEM
-1. **Seleccionar fuentes de telemetría** asociadas al laboratorio y asegurarse de que la clasificación de eventos coincide con los escenarios del Subcaso 1d.
-2. **Publicar reglas de correlación** específicas que generen alertas priorizadas hacia NG-SOC.
-3. **Habilitar intercambio con CTI-SS** para enriquecer automáticamente los incidentes con inteligencia de amenazas vigente.
+1. **Select telemetry sources** associated with the lab and confirm that event classification matches the Subcase 1d scenarios.
+2. **Publish correlation rules** that raise prioritised alerts towards NG-SOC.
+3. **Enable exchange with CTI-SS** to enrich incidents automatically with current threat intelligence.
 
 ## NG-SOAR
-1. **Importar playbooks CACAO** recibidos desde NG-SOC y validar su integridad en el repositorio interno.
-2. **Configurar conectores** hacia CICMS Operator, CTI-SS y la biblioteca de playbooks asegurando credenciales de servicio y certificados actualizados.
-3. **Definir colas de ejecución** para separar tareas automáticas de las que requieren intervención manual supervisada por CICMS Operator.
+1. **Import CACAO playbooks** received from NG-SOC and verify their integrity in the internal repository.
+2. **Configure connectors** to CICMS Operator, CTI-SS and the playbook library, ensuring service credentials and certificates are up to date.
+3. **Define execution queues** to separate automated tasks from those requiring manual intervention supervised by the CICMS Operator.
 
 ## CICMS Operator
-1. **Registrar procesos de apoyo** vinculados a los playbooks CACAO (aprobaciones, revisiones, tareas de campo) dentro del flujo operativo.
-2. **Establecer SLA y notificaciones** para cada actividad manual, direccionando las alertas a los grupos operativos de NG-SOC.
-3. **Sincronizar el panel de seguimiento** con NG-SOAR para recibir hitos de ejecución y devolver confirmaciones de cierre.
+1. **Register support processes** linked to the CACAO playbooks (approvals, reviews, field tasks) within the operational flow.
+2. **Set SLAs and notifications** for each manual activity, routing alerts to the NG-SOC operational groups.
+3. **Synchronise the tracking dashboard** with NG-SOAR to receive execution milestones and return closure confirmations.
 
 ## CTI-SS
-1. **Seleccionar fuentes de inteligencia** relevantes al ejercicio y actualizar los feeds de indicadores.
-2. **Publicar taxonomías y etiquetas** que NG-SOAR utilizará para clasificar indicadores durante el enriquecimiento.
-3. **Sincronizar conocimiento con la biblioteca de playbooks** para que las lecciones aprendidas incorporen contexto de amenazas vigente.
+1. **Select relevant intelligence sources** for the exercise and update the indicator feeds.
+2. **Publish taxonomies and tags** that NG-SOAR will use to classify indicators during enrichment.
+3. **Synchronise knowledge with the playbook library** so lessons learnt include up-to-date threat context.
 
-## Biblioteca de playbooks/estándares
-1. **Definir el espacio de conocimiento** del Subcaso 1d, incorporando referencias MITRE ATT&CK, NVD y NIST aplicables.
-2. **Configurar integraciones** para recibir datos de NG-SOC, NG-SOAR y CICMS Operator mediante conectores autenticados.
-3. **Habilitar versionado** automático de documentos para conservar la evolución de los playbooks y procedimientos.
+## Playbook/standards library
+1. **Define the knowledge space** for Subcase 1d, incorporating applicable MITRE ATT&CK, NVD and NIST references.
+2. **Configure integrations** to receive data from NG-SOC, NG-SOAR and CICMS Operator through authenticated connectors.
+3. **Enable automatic versioning** of documents to preserve the evolution of playbooks and procedures.
 
-## Validación final
-- Revisar desde NG-SOC que todos los componentes respondan a pruebas de conectividad.
-- Ejecutar un playbook CACAO de verificación y confirmar que CICMS Operator, CTI-SS y la biblioteca de playbooks registran actividad.
-- Documentar los resultados en CICMS Operator y notificar a los responsables del ejercicio.
+## Final validation
+- Check from NG-SOC that all components respond to connectivity tests.
+- Run a CACAO verification playbook and confirm that CICMS Operator, CTI-SS and the playbook library record activity.
+- Document the results in CICMS Operator and notify the exercise owners.

--- a/topology.yml
+++ b/topology.yml
@@ -2,12 +2,12 @@ name: cyberrangecz_core
 version: 1
 components:
   instructor_console:
-    purpose: "Preparar y monitorizar las sesiones educativas del subcaso 1a."
+    purpose: "Prepare and monitor the educational sessions for subcase 1a."
     integrations:
       - random_education_platform
       - reporting_workspace
   random_education_platform:
-    purpose: "Gestionar el contenido teórico, cuestionarios y laboratorios prácticos para trainees."
+    purpose: "Manage theoretical content, quizzes and hands-on labs for trainees."
     modules:
       - scheduler
       - live_session
@@ -18,52 +18,52 @@ components:
       - trainee_workstations
       - reporting_workspace
   trainee_workstations:
-    purpose: "Acceso de los/las trainees a los contenidos y laboratorios de CyberRangeCZ."
+    purpose: "Provide trainees with access to CyberRangeCZ content and labs."
     integrations:
       - random_education_platform
       - cyberrange_simulators
   reporting_workspace:
-    purpose: "Consolidar métricas y resultados de cuestionarios/pruebas para el instructor."
+    purpose: "Consolidate metrics and quiz/lab results for the instructor."
     integrations:
       - random_education_platform
       - instructor_console
   cyberrange_simulators:
-    purpose: "Escenarios prácticos utilizados en los ejercicios del subcaso 1a."
+    purpose: "Practical scenarios used in the exercises for subcase 1a."
     integrations:
       - random_education_platform
 
   ng_soc:
-    purpose: "Centro de operaciones que coordina la respuesta del subcaso 1d."
+    purpose: "Operations centre that coordinates the response for subcase 1d."
     integrations:
       - ng_siem
       - ng_soar
       - cicms_operator
       - playbook_library
   ng_siem:
-    purpose: "Plataforma de correlación y priorización de eventos."
+    purpose: "Platform for correlating and prioritising events."
     integrations:
       - ng_soc
       - cti_ss
   ng_soar:
-    purpose: "Motor de ejecución de playbooks CACAO."
+    purpose: "Execution engine for CACAO playbooks."
     integrations:
       - ng_soc
       - cti_ss
       - cicms_operator
       - playbook_library
   cti_ss:
-    purpose: "Servicio de inteligencia de amenazas que enriquece indicadores."
+    purpose: "Threat intelligence service that enriches indicators."
     integrations:
       - ng_siem
       - ng_soar
   cicms_operator:
-    purpose: "Operador que consolida evidencias, reportes y validaciones manuales del incidente."
+    purpose: "Operator that consolidates evidence, reports and manual incident validations."
     integrations:
       - ng_soc
       - ng_soar
       - playbook_library
   playbook_library:
-    purpose: "Repositorio de playbooks y estándares (NVD/NIST, MITRE ATT&CK) usado para guiar la respuesta."
+    purpose: "Repository of playbooks and standards (NVD/NIST, MITRE ATT&CK) used to guide the response."
     integrations:
       - ng_soc
       - ng_soar

--- a/training_linear.json
+++ b/training_linear.json
@@ -1,113 +1,113 @@
 {
   "name": "CyberRangeCZ Practical Modules",
-  "description": "Secuencia de aprendizaje para los subcasos 1a y 1d del entorno CyberRangeCZ, orientada a instructores y equipos operativos.",
+  "description": "Learning sequence for subcases 1a and 1d in the CyberRangeCZ environment, aimed at instructors and operations teams.",
   "modules": [
     {
       "id": "subcase-1a",
-      "title": "Subcaso 1a - Entrenamiento guiado por instructor",
+      "title": "Subcase 1a - Instructor-led training",
       "phases": [
         {
-          "name": "Planificación de la sesión",
+          "name": "Session planning",
           "activities": [
             {
               "step": 1,
-              "description": "El instructor define objetivos, materiales y tiempos de la sesión en el panel de control de CyberRangeCZ.",
-              "tools": ["Consola del instructor", "Repositorio de contenidos CyberRangeCZ"]
+              "description": "The instructor defines objectives, materials and timings for the session within the CyberRangeCZ control panel.",
+              "tools": ["Instructor console", "CyberRangeCZ content repository"]
             },
             {
               "step": 2,
-              "description": "Se programa la actividad en la Random Education Platform (REP) asignando los módulos introductorios.",
+              "description": "The activity is scheduled in the Random Education Platform (REP) by assigning the introductory modules.",
               "tools": ["Random Education Platform - Scheduler"]
             }
           ]
         },
         {
-          "name": "Desarrollo de la clase en REP",
+          "name": "Delivering the class on REP",
           "activities": [
             {
               "step": 3,
-              "description": "El instructor inicia la sesión en vivo, presenta objetivos y activa los canales colaborativos (chat, videoconferencia, pizarra).",
-              "tools": ["Random Education Platform - Live Session", "Herramientas colaborativas integradas"]
+              "description": "The instructor starts the live session, presents objectives and enables the collaborative channels (chat, videoconferencing, whiteboard).",
+              "tools": ["Random Education Platform - Live Session", "Integrated collaborative tools"]
             },
             {
               "step": 4,
-              "description": "La REP distribuye automáticamente cápsulas teóricas breves y simulaciones guiadas a cada trainee.",
-              "tools": ["Random Education Platform - Content Delivery", "Simuladores CyberRangeCZ"]
+              "description": "REP automatically distributes short theory capsules and guided simulations to each trainee.",
+              "tools": ["Random Education Platform - Content Delivery", "CyberRangeCZ simulators"]
             }
           ]
         },
         {
-          "name": "Cuestionarios formativos",
+          "name": "Formative quizzes",
           "activities": [
             {
               "step": 5,
-              "description": "Los trainees responden cuestionarios interactivos con feedback inmediato.",
+              "description": "Trainees answer interactive quizzes with immediate feedback.",
               "tools": ["Random Education Platform - Quiz Engine"]
             },
             {
               "step": 6,
-              "description": "El instructor revisa los resultados en tiempo real para identificar dudas y reforzar los puntos clave.",
-              "tools": ["Panel analítico de la REP", "Consola del instructor"]
+              "description": "The instructor reviews real-time results to identify questions and reinforce key points.",
+              "tools": ["REP analytics dashboard", "Instructor console"]
             }
           ]
         },
         {
-          "name": "Pruebas prácticas y retroalimentación",
+          "name": "Practical tests and feedback",
           "activities": [
             {
               "step": 7,
-              "description": "Se lanzan laboratorios o retos supervisados vinculados al contenido teórico.",
-              "tools": ["Random Education Platform - Practical Labs", "Entorno CyberRangeCZ"]
+              "description": "Supervised labs or challenges linked to the theoretical content are launched.",
+              "tools": ["Random Education Platform - Practical Labs", "CyberRangeCZ environment"]
             },
             {
               "step": 8,
-              "description": "La REP consolida resultados y genera un informe que el instructor utiliza para la retroalimentación final.",
-              "tools": ["Random Education Platform - Reporting", "Panel del instructor"]
+              "description": "REP consolidates results and produces a report the instructor uses for the final feedback session.",
+              "tools": ["Random Education Platform - Reporting", "Instructor dashboard"]
             }
           ]
         },
         {
-          "name": "Simulación de spear phishing multicanal",
+          "name": "Multi-channel spear phishing simulation",
           "activities": [
             {
               "step": 9,
-              "description": "El instructor activa una campaña de spear phishing que combina correo, SMS y voz para evaluar la respuesta inicial de los trainees.",
-              "tools": ["Simulador de spear phishing multicanal", "Integraciones de correo/SMS/VoIP de CyberRangeCZ"]
+              "description": "The instructor activates a spear phishing campaign combining email, SMS and voice to assess the trainees' initial response.",
+              "tools": ["Multi-channel spear phishing simulator", "CyberRangeCZ email/SMS/VoIP integrations"]
             },
             {
               "step": 10,
-              "description": "Los trainees inspeccionan los vectores de ataque, reportan indicadores sospechosos y documentan hallazgos en los formularios de la REP.",
-              "tools": ["Random Education Platform - Incident Forms", "Panel de telemetría de simulación"]
+              "description": "Trainees inspect attack vectors, report suspicious indicators and document findings in REP forms.",
+              "tools": ["Random Education Platform - Incident Forms", "Simulation telemetry dashboard"]
             }
           ]
         },
         {
-          "name": "Cadena de respuesta colaborativa",
+          "name": "Collaborative response chain",
           "activities": [
             {
               "step": 11,
-              "description": "Se crea una sala de coordinación para activar la cadena de respuesta, integrando chat seguro, videoconferencia y tablero de tareas en la REP.",
-              "tools": ["Random Education Platform - Collaboration Hub", "Tablero Kanban de incidentes"]
+              "description": "A coordination room is created to activate the response chain, integrating secure chat, videoconferencing and a task board in REP.",
+              "tools": ["Random Education Platform - Collaboration Hub", "Incident Kanban board"]
             },
             {
               "step": 12,
-              "description": "Los trainees asignan roles, comparten evidencias y validan contramedidas a través de la consola colaborativa del instructor.",
-              "tools": ["Consola colaborativa del instructor", "Repositorio compartido de evidencias"]
+              "description": "Trainees assign roles, share evidence and validate countermeasures through the instructor's collaborative console.",
+              "tools": ["Instructor collaborative console", "Shared evidence repository"]
             }
           ]
         },
         {
-          "name": "Informe forense exprés",
+          "name": "Express forensic report",
           "activities": [
             {
               "step": 13,
-              "description": "Se recolectan artefactos críticos del ejercicio (cabeceras, registros, capturas) para alimentar el informe exprés.",
-              "tools": ["Repositorio de artefactos forenses", "Exportador de registros de la REP"]
+              "description": "Critical artefacts from the exercise (headers, logs, captures) are collected to feed the express report.",
+              "tools": ["Forensic artefact repository", "REP log exporter"]
             },
             {
               "step": 14,
-              "description": "El instructor consolida hallazgos y recomendaciones en la plantilla de informe forense exprés y lo distribuye a los participantes.",
-              "tools": ["Plantillas de informe forense exprés", "Consola del instructor"]
+              "description": "The instructor compiles findings and recommendations in the express forensic report template and shares it with participants.",
+              "tools": ["Express forensic report templates", "Instructor console"]
             }
           ]
         }
@@ -115,100 +115,100 @@
     },
     {
       "id": "subcase-1d",
-      "title": "Subcaso 1d - Operación NG-SOC",
+      "title": "Subcase 1d - NG-SOC operation",
       "phases": [
         {
-          "name": "Monitorización y detección",
+          "name": "Monitoring and detection",
           "activities": [
             {
               "step": 1,
-              "description": "NG-SIEM recopila telemetría del entorno CyberRangeCZ y genera una alerta priorizada.",
+              "description": "NG-SIEM gathers telemetry from the CyberRangeCZ environment and raises a prioritised alert.",
               "tools": ["NG-SIEM"]
             },
             {
               "step": 2,
-              "description": "El analista de NG-SOC valida la alerta y selecciona el playbook CACAO apropiado.",
-              "tools": ["Consola NG-SOC", "Repositorio de playbooks CACAO"]
+              "description": "The NG-SOC analyst validates the alert and selects the appropriate CACAO playbook.",
+              "tools": ["NG-SOC console", "CACAO playbook repository"]
             }
           ]
         },
         {
-          "name": "Orquestación del playbook",
+          "name": "Playbook orchestration",
           "activities": [
             {
               "step": 3,
-              "description": "NG-SOC envía la orden de ejecución a NG-SOAR junto con los parámetros del incidente.",
+              "description": "NG-SOC sends the execution order to NG-SOAR together with the incident parameters.",
               "tools": ["NG-SOC Orchestrator", "NG-SOAR API"]
             },
             {
               "step": 4,
-              "description": "NG-SOAR interpreta la secuencia CACAO y prepara las acciones automáticas y manuales requeridas.",
-              "tools": ["NG-SOAR Engine", "Modelo CACAO"]
+              "description": "NG-SOAR interprets the CACAO sequence and prepares the required automated and manual actions.",
+              "tools": ["NG-SOAR Engine", "CACAO model"]
             },
             {
               "step": 5,
-              "description": "Se habilita el playbook CACAO específico contra ransomware, mapeando controles de contención y recuperación a los conectores disponibles.",
-              "tools": ["Repositorio de playbooks CACAO", "Plantilla CACAO Ransomware", "NG-SOAR Playbook Manager"]
+              "description": "The specific CACAO playbook against ransomware is enabled, mapping containment and recovery controls to the available connectors.",
+              "tools": ["CACAO playbook repository", "CACAO ransomware template", "NG-SOAR Playbook Manager"]
             }
           ]
         },
         {
-          "name": "Ejecución automatizada",
+          "name": "Automated execution",
           "activities": [
             {
               "step": 6,
-              "description": "El playbook ejecuta tareas de enriquecimiento, contención y notificación sobre los activos afectados.",
-              "tools": ["NG-SOAR Connectors", "Integraciones de endpoint y red"]
+              "description": "The playbook performs enrichment, containment and notification tasks on the affected assets.",
+              "tools": ["NG-SOAR connectors", "Endpoint and network integrations"]
             },
             {
               "step": 7,
-              "description": "Se registran métricas de tiempo de respuesta y efectividad para su seguimiento posterior.",
-              "tools": ["NG-SOAR Metrics", "Dashboard NG-SOC"]
+              "description": "Response time and effectiveness metrics are recorded for later tracking.",
+              "tools": ["NG-SOAR Metrics", "NG-SOC dashboard"]
             },
             {
               "step": 8,
-              "description": "Se ejecuta una prueba de resiliencia de conectores para validar la disponibilidad de integraciones críticas tras la contención.",
-              "tools": ["NG-SOAR Connector Health Check", "Monitor de integraciones NG-SOC"]
+              "description": "A connector resilience test is executed to confirm availability of critical integrations after containment.",
+              "tools": ["NG-SOAR Connector Health Check", "NG-SOC integration monitor"]
             }
           ]
         },
         {
-          "name": "Apoyo de sistemas transversales",
+          "name": "Support from transversal systems",
           "activities": [
             {
               "step": 9,
-              "description": "CICMS Operator centraliza evidencias y reportes asociados al incidente mientras se ejecuta el playbook.",
+              "description": "CICMS Operator centralises evidence and reports associated with the incident while the playbook is running.",
               "tools": ["CICMS Operator"]
             },
             {
               "step": 10,
-              "description": "CTI-SS aporta inteligencia de amenazas para enriquecer indicadores y decidir contramedidas.",
+              "description": "CTI-SS supplies threat intelligence to enrich indicators and determine countermeasures.",
               "tools": ["CTI-SS"]
             },
             {
               "step": 11,
-              "description": "La biblioteca de playbooks y estándares (NVD/NIST, MITRE ATT&CK) guía la adaptación del plan de respuesta.",
-              "tools": ["Biblioteca de playbooks/estándares"]
+              "description": "The playbook and standards library (NVD/NIST, MITRE ATT&CK) guides the adaptation of the response plan.",
+              "tools": ["Playbook/standards library"]
             }
           ]
         },
         {
-          "name": "Cierre y retroalimentación",
+          "name": "Closure and feedback",
           "activities": [
             {
               "step": 12,
-              "description": "NG-SOAR actualiza el estado del incidente en NG-SOC/NG-SIEM y consolida la documentación del caso.",
-              "tools": ["NG-SOAR", "Consola NG-SOC", "NG-SIEM"]
+              "description": "NG-SOAR updates the incident status in NG-SOC/NG-SIEM and consolidates the case documentation.",
+              "tools": ["NG-SOAR", "NG-SOC console", "NG-SIEM"]
             },
             {
               "step": 13,
-              "description": "CICMS Operator consolida el reporte post-incidente y enlaza las lecciones aprendidas en la biblioteca de playbooks.",
-              "tools": ["CICMS Operator", "Biblioteca de playbooks/estándares"]
+              "description": "CICMS Operator compiles the post-incident report and links the lessons learnt in the playbook library.",
+              "tools": ["CICMS Operator", "Playbook/standards library"]
             },
             {
               "step": 14,
-              "description": "Se activa la mesa de control post-incidente para presentar hallazgos técnicos, validar acciones correctivas y planificar la mejora continua.",
-              "tools": ["Mesa de control NG-SOC", "Dashboard ejecutivo", "Repositorio de lecciones aprendidas"]
+              "description": "The post-incident control board is convened to present technical findings, validate corrective actions and plan continual improvement.",
+              "tools": ["NG-SOC control board", "Executive dashboard", "Lessons-learnt repository"]
             }
           ]
         }


### PR DESCRIPTION
## Summary
- translate the root README and supporting documentation into British English while retaining structure and technical terms
- update provisioning guides and topology metadata with British English terminology for operational consistency
- convert training module JSON descriptions to British English phrasing to align the educational flow

## Testing
- not run (documentation-only changes)


------
https://chatgpt.com/codex/tasks/task_e_68d1171d6e58832da8e8bf695eeca00e