### PR TITLE
Add KYPO topologies and Ansible provisioning for subcases 1a and 1d

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,8 +44,9 @@ The detailed flow for each subcase is summarised below to facilitate reproductio
 
 - `training_linear.json`: lists the learning modules for subcases 1a and 1d, including step-by-step activities and the tools involved.
 - `topology.yml`: describes the CyberRangeCZ components relevant to the exercises and how they integrate with the educational and operational tooling.
-- `docs/`: support materials and complementary guides.
+- `docs/`: support materials and complementary guides. `docs/provisioning-guide.md` explains how to deploy the infrastructure required for each subcase.
 - `inventory.sample`: template inventory with placeholder credentials; load secrets at runtime via Ansible Vault or environment variables instead of committing them to version control.
+- `provisioning/`: KYPO topology files and Ansible playbooks that replicate the infrastructure defined in the CYNET activity diagram for the 1a and 1d flows.
 
 ## Credential management
 

--- a/docs/provisioning-guide.md
+++ b/docs/provisioning-guide.md
@@ -1,0 +1,71 @@
+# Provisioning workflow for subcases 1a and 1d
+
+This guide explains how to instantiate the CyberRangeCZ infrastructure aligned with the CYNET activity diagram. The process is divided into two phases: importing the KYPO topology and configuring the virtual machines with Ansible.
+
+## 1. Import the topology in KYPO
+
+1. Sign in to the KYPO portal with an account that can create sandboxes.
+2. For subcase **1a**, upload `provisioning/subcase-1a-topology.yml`. The topology creates:
+   - REP backend servers (`rep-scheduler`, `rep-live-session`, `rep-quiz-engine`, `rep-practical-labs`).
+   - Instructor and trainee workstations connected to the `rep-frontend` network.
+   - The `reporting-workspace` node on the analytics segment.
+3. For subcase **1d**, upload `provisioning/subcase-1d-topology.yml` to provision:
+   - Core NG-SOC hosts (`ng-soc`, `ng-siem`, `ng-soar`).
+   - Supporting services (`cti-ss`, `cicms-operator`, `playbook-library`, `telemetry-simulator`).
+   - Segmented networks that emulate the SOC, automation, intelligence, coordination and telemetry zones.
+4. Deploy the sandbox and wait for KYPO to report that all machines are reachable.
+
+## 2. Prepare credentials
+
+1. Duplicate `inventory.sample` and rename it to `inventory.yml` (or similar).
+2. Keep the hostnames and IP addresses defined by the topology files.
+3. Export credentials as environment variables before executing Ansible, for example:
+
+```bash
+export ANSIBLE_PASSWORD_REP_SCHEDULER='********'
+export ANSIBLE_PASSWORD_NG_SOC='********'
+```
+
+4. If you prefer to store secrets in Ansible Vault files, replace the `lookup('env', ...)` expressions with `ansible-vault` variables and reference the vault when running the playbooks.
+
+## 3. Install Ansible dependencies
+
+```bash
+python3 -m pip install --upgrade ansible
+ansible-galaxy collection install ansible.windows community.general
+```
+
+- Windows connectivity for trainee machines requires WinRM over TLS (port 5986). Configure certificates or use the inventory option `ansible_winrm_server_cert_validation=ignore` for lab environments.
+
+## 4. Execute the playbooks
+
+### Subcase 1a
+
+```bash
+ansible-playbook -i inventory.yml provisioning/subcase-1a/site.yml
+```
+
+The playbook:
+- Installs web and application dependencies on the REP backend servers.
+- Prepares the reporting workspace dashboards.
+- Customises the instructor console.
+- Creates working folders for trainee machines.
+
+### Subcase 1d
+
+```bash
+ansible-playbook -i inventory.yml provisioning/subcase-1d/site.yml
+```
+
+This playbook configures the NG ecosystem by installing packages, enabling services and seeding working directories that match the operational flow described in the NG-SOC documentation.
+
+Use tags (e.g. `--tags ng_soar`) to target specific components during troubleshooting.
+
+## 5. Validation steps
+
+- Check SSH or WinRM connectivity with `ansible all -i inventory.yml -m ping` (use `ansible.windows.win_ping` for Windows groups).
+- Verify that key services are running (`nginx` on the playbook library, `redis-server` on NG-SOAR, `grafana-server` on the reporting workspace).
+- Trigger the telemetry simulator script (`/opt/telemetry-simulator/scenarios/generate.sh`) and confirm that NG-SIEM receives events through `rsyslog`.
+- Confirm that trainees can access the `WELCOME.txt` note in `C:\Labs` and that the instructor console has the `rep-notes` workspace.
+
+Following these steps ensures the infrastructure mirrors the flows of subcases 1a and 1d and is ready for the exercises described in `docs/subcase-1a-phishing-awareness.md` and `docs/subcase-1d-playbook-automation.md`.

--- a/inventory.sample
+++ b/inventory.sample
@@ -1,34 +1,39 @@
 # NOTE: Store real credentials in Ansible Vault or environment variables before running playbooks.
+# Example: export ANSIBLE_PASSWORD_REP_SCHEDULER and reference it as ansible_password="{{ lookup('env', 'ANSIBLE_PASSWORD_REP_SCHEDULER') }}"
 
 [random_education_platform]
-rep ansible_host=10.10.10.20 ansible_user=admin ansible_password="<set via Ansible Vault or env var>"
+rep-scheduler ansible_host=10.20.10.10 ansible_user=ubuntu ansible_password="{{ lookup('env', 'ANSIBLE_PASSWORD_REP_SCHEDULER') }}"
+rep-live-session ansible_host=10.20.10.20 ansible_user=ubuntu ansible_password="{{ lookup('env', 'ANSIBLE_PASSWORD_REP_LIVE') }}"
+rep-quiz-engine ansible_host=10.20.10.30 ansible_user=ubuntu ansible_password="{{ lookup('env', 'ANSIBLE_PASSWORD_REP_QUIZ') }}"
+rep-practical-labs ansible_host=10.20.10.40 ansible_user=ubuntu ansible_password="{{ lookup('env', 'ANSIBLE_PASSWORD_REP_LABS') }}"
 
 [instructor_console]
-instructor-console ansible_host=CHANGEME ansible_user=CHANGEME ansible_password="<set via Ansible Vault or env var>"
+instructor-console ansible_host=10.20.20.10 ansible_user=ubuntu ansible_password="{{ lookup('env', 'ANSIBLE_PASSWORD_INSTRUCTOR') }}"
 
-[trainee_workstations]
-trainee-workstations ansible_host=CHANGEME ansible_user=CHANGEME ansible_password="<set via Ansible Vault or env var>"
+[trainees]
+trainee-workstation-01 ansible_host=10.20.20.50 ansible_user=Administrator ansible_password="{{ lookup('env', 'ANSIBLE_PASSWORD_TRAINEE1') }}" ansible_connection=winrm ansible_port=5986 ansible_winrm_server_cert_validation=ignore
+trainee-workstation-02 ansible_host=10.20.20.60 ansible_user=Administrator ansible_password="{{ lookup('env', 'ANSIBLE_PASSWORD_TRAINEE2') }}" ansible_connection=winrm ansible_port=5986 ansible_winrm_server_cert_validation=ignore
 
 [reporting_workspace]
-reporting-workspace ansible_host=CHANGEME ansible_user=CHANGEME ansible_password="<set via Ansible Vault or env var>"
-
-[cyberrange_simulators]
-cyberrange-simulators ansible_host=CHANGEME ansible_user=CHANGEME ansible_password="<set via Ansible Vault or env var>"
+reporting-workspace ansible_host=10.20.30.10 ansible_user=ubuntu ansible_password="{{ lookup('env', 'ANSIBLE_PASSWORD_REPORTING') }}"
 
 [ng_soc]
-ng-soc ansible_host=10.10.20.10 ansible_user=socops ansible_password="<set via Ansible Vault or env var>"
+ng-soc ansible_host=10.30.10.10 ansible_user=ubuntu ansible_password="{{ lookup('env', 'ANSIBLE_PASSWORD_NG_SOC') }}"
 
 [ng_siem]
-ng-siem ansible_host=10.10.20.11 ansible_user=siemsvc ansible_password="<set via Ansible Vault or env var>"
+ng-siem ansible_host=10.30.10.20 ansible_user=ubuntu ansible_password="{{ lookup('env', 'ANSIBLE_PASSWORD_NG_SIEM') }}"
 
 [ng_soar]
-ng-soar ansible_host=10.10.20.12 ansible_user=soarops ansible_password="<set via Ansible Vault or env var>"
+ng-soar ansible_host=10.30.20.10 ansible_user=ubuntu ansible_password="{{ lookup('env', 'ANSIBLE_PASSWORD_NG_SOAR') }}"
 
 [cti_ss]
-cti-ss ansible_host=10.10.30.12 ansible_user=ctisvc ansible_password="<set via Ansible Vault or env var>"
+cti-ss ansible_host=10.30.30.10 ansible_user=ubuntu ansible_password="{{ lookup('env', 'ANSIBLE_PASSWORD_CTI_SS') }}"
 
-[cicms_operator]
-cicms-operator ansible_host=CHANGEME ansible_user=CHANGEME ansible_password="<set via Ansible Vault or env var>"
+[cicms]
+cicms-operator ansible_host=10.30.40.10 ansible_user=ubuntu ansible_password="{{ lookup('env', 'ANSIBLE_PASSWORD_CICMS') }}"
 
 [playbook_library]
-playbook-library ansible_host=CHANGEME ansible_user=CHANGEME ansible_password="<set via Ansible Vault or env var>"
+playbook-library ansible_host=10.30.30.20 ansible_user=ubuntu ansible_password="{{ lookup('env', 'ANSIBLE_PASSWORD_LIBRARY') }}"
+
+[telemetry_feeder]
+telemetry-simulator ansible_host=10.30.50.10 ansible_user=ubuntu ansible_password="{{ lookup('env', 'ANSIBLE_PASSWORD_TELEMETRY') }}"

--- a/provisioning/README.md
+++ b/provisioning/README.md
@@ -1,8 +1,17 @@
-# Enablement artefacts for CyberRangeCZ
+# Provisioning artefacts for CyberRangeCZ
 
-This directory no longer contains provisioning playbooks. Instead, it hosts reference artefacts that enable the Random Education Platform (REP) and the NG-SOC/NG-SIEM/NG-SOAR/CICMS Operator/CTI-SS/Playbook Library services described in Subcase 1d.
+The `provisioning/` directory contains topology definitions and Ansible playbooks that reproduce the infrastructure flows of subcases 1a and 1d from the CYNET activity diagram.
 
-- `subcase-1d-services.md` documents how to activate and connect each component.
-- `cacao-playbook-automation.md` sets out the automated procedures for managing the CACAO playbook lifecycle within NG-SOAR and its integration with CICMS Operator, CTI-SS and the playbook library.
+## Topology files
 
-Each artefact focuses exclusively on the capabilities shown in the subcase diagram and omits dependencies on external tooling unrelated to the NG ecosystem.
+- `subcase-1a-topology.yml` – KYPO topology describing the Random Education Platform (REP) components used in the phishing awareness exercise.
+- `subcase-1d-topology.yml` – KYPO topology for the NG-SOC, NG-SIEM, NG-SOAR, CTI-SS, CICMS Operator, playbook library and telemetry simulator services.
+
+These files can be imported into KYPO to instantiate the virtual machines, routers and networks ahead of running the configuration playbooks.
+
+## Playbooks
+
+- `subcase-1a/` – Roles and site playbook that prepare REP backends, the instructor console, trainee workstations and the reporting workspace.
+- `subcase-1d/` – Roles and site playbook to configure NG-SOC automation components, intelligence services and the telemetry generator.
+
+Each subdirectory includes a README with prerequisites, variable references and execution instructions. Install the required Ansible collections before running the playbooks and store credentials using Ansible Vault or environment variables instead of plain text files.

--- a/provisioning/subcase-1a-topology.yml
+++ b/provisioning/subcase-1a-topology.yml
@@ -1,0 +1,95 @@
+name: subcase_1a_phishing_awareness
+hosts:
+  - name: instructor-console
+    base_box:
+      image: ubuntu-noble-x86_64
+      mgmt_user: ubuntu
+    flavor: standard.small
+  - name: rep-scheduler
+    base_box:
+      image: ubuntu-noble-x86_64
+      mgmt_user: ubuntu
+    flavor: standard.small
+  - name: rep-live-session
+    base_box:
+      image: ubuntu-noble-x86_64
+      mgmt_user: ubuntu
+    flavor: standard.small
+  - name: rep-quiz-engine
+    base_box:
+      image: ubuntu-noble-x86_64
+      mgmt_user: ubuntu
+    flavor: standard.small
+  - name: rep-practical-labs
+    base_box:
+      image: ubuntu-noble-x86_64
+      mgmt_user: ubuntu
+    flavor: standard.medium
+  - name: reporting-workspace
+    base_box:
+      image: ubuntu-noble-x86_64
+      mgmt_user: ubuntu
+    flavor: standard.medium
+  - name: trainee-workstation-01
+    base_box:
+      image: windows10-x64
+      mgmt_user: Administrator
+      mgmt_protocol: winrm
+    flavor: standard.medium
+  - name: trainee-workstation-02
+    base_box:
+      image: windows10-x64
+      mgmt_user: Administrator
+      mgmt_protocol: winrm
+    flavor: standard.medium
+routers:
+  - name: rep-gateway
+    base_box:
+      image: debian-12-x86_64
+      mgmt_user: debian
+    flavor: standard.small
+networks:
+  - name: rep-backend
+    cidr: 10.20.10.0/24
+    accessible_by_user: False
+  - name: rep-frontend
+    cidr: 10.20.20.0/24
+    accessible_by_user: True
+  - name: analytics-zone
+    cidr: 10.20.30.0/24
+    accessible_by_user: False
+net_mappings:
+  - host: rep-scheduler
+    network: rep-backend
+    ip: 10.20.10.10
+  - host: rep-live-session
+    network: rep-backend
+    ip: 10.20.10.20
+  - host: rep-quiz-engine
+    network: rep-backend
+    ip: 10.20.10.30
+  - host: rep-practical-labs
+    network: rep-backend
+    ip: 10.20.10.40
+  - host: instructor-console
+    network: rep-frontend
+    ip: 10.20.20.10
+  - host: trainee-workstation-01
+    network: rep-frontend
+    ip: 10.20.20.50
+  - host: trainee-workstation-02
+    network: rep-frontend
+    ip: 10.20.20.60
+  - host: reporting-workspace
+    network: analytics-zone
+    ip: 10.20.30.10
+router_mappings:
+  - router: rep-gateway
+    network: rep-backend
+    ip: 10.20.10.1
+  - router: rep-gateway
+    network: rep-frontend
+    ip: 10.20.20.1
+  - router: rep-gateway
+    network: analytics-zone
+    ip: 10.20.30.1

--- a/provisioning/subcase-1a/README.md
+++ b/provisioning/subcase-1a/README.md
@@ -1,0 +1,45 @@
+# Subcase 1a – Provisioning guide
+
+The playbooks in this directory prepare the infrastructure required by the phishing awareness exercises delivered on the Random Education Platform (REP).
+
+## Host groups
+
+| Inventory group | Hosts | Purpose |
+| --- | --- | --- |
+| `rep_core` | `rep-scheduler`, `rep-live-session`, `rep-quiz-engine`, `rep-practical-labs` | Backend services that coordinate course scheduling, live delivery, quizzes and practical labs. |
+| `reporting_workspace` | `reporting-workspace` | Dashboards and report consolidation workspace. |
+| `instructor_console` | `instructor-console` | Entry point for instructors to manage the live session. |
+| `trainees` | `trainee-workstation-01`, `trainee-workstation-02` | Windows workstations used by participants during the labs. |
+
+## Requirements
+
+- Ansible 2.15 or newer with the `ansible.windows` and `community.general` collections installed.
+- Network reachability towards the hosts defined in `provisioning/subcase-1a-topology.yml`.
+- Credentials provided through Ansible Vault files or environment variables (see `inventory.sample`).
+
+Install the collections with:
+
+```bash
+ansible-galaxy collection install ansible.windows community.general
+```
+
+## Running the playbook
+
+1. Export sensitive variables or prepare an Ansible Vault file that contains the required passwords.
+2. Copy `inventory.sample` to a working inventory file and adjust the host addresses if necessary.
+3. Execute the site playbook:
+
+```bash
+ansible-playbook -i inventory.yml provisioning/subcase-1a/site.yml
+```
+
+## Variables
+
+The roles expect the following optional variables that can be set in inventory or extra vars:
+
+- `rep_core_packages`: list of additional packages for the REP backend servers (defaults to `['nginx', 'python3-venv']`).
+- `reporting_workspace_packages`: analytics tooling to install (defaults to `['postgresql', 'grafana']`).
+- `instructor_console_packages`: productivity tooling for the instructor (defaults to `['tmux', 'htop']`).
+- `trainee_workspace_resources`: folders created on Windows workstations (defaults to `['C:\\Labs', 'C:\\Labs\\Evidence']`).
+
+Override them by passing `-e` or defining group variables as required by the exercise scenario.

--- a/provisioning/subcase-1a/roles/instructor_console/tasks/main.yml
+++ b/provisioning/subcase-1a/roles/instructor_console/tasks/main.yml
@@ -1,0 +1,25 @@
+---
+- name: Install instructor tooling
+  ansible.builtin.apt:
+    name: "{{ instructor_console_packages | default(['tmux', 'htop']) }}"
+    state: present
+    update_cache: true
+
+- name: Configure instructor notes workspace
+  ansible.builtin.file:
+    path: /home/ubuntu/rep-notes
+    state: directory
+    owner: ubuntu
+    group: ubuntu
+    mode: '0750'
+
+- name: Deploy welcome message
+  ansible.builtin.copy:
+    dest: /home/ubuntu/rep-notes/README.txt
+    content: |
+      Random Education Platform – Instructor Console
+      -----------------------------------------------
+      Use this folder to store agendas, collaborative links and post-session summaries.
+    owner: ubuntu
+    group: ubuntu
+    mode: '0640'

--- a/provisioning/subcase-1a/roles/rep_core/tasks/main.yml
+++ b/provisioning/subcase-1a/roles/rep_core/tasks/main.yml
@@ -1,0 +1,24 @@
+---
+- name: Ensure apt cache is up to date
+  ansible.builtin.apt:
+    update_cache: true
+    cache_valid_time: 3600
+
+- name: Install REP backend packages
+  ansible.builtin.apt:
+    name: "{{ rep_core_packages | default(['nginx', 'python3-venv']) }}"
+    state: present
+
+- name: Enable nginx service
+  ansible.builtin.service:
+    name: nginx
+    enabled: true
+    state: started
+
+- name: Create REP configuration directory
+  ansible.builtin.file:
+    path: /opt/rep/config
+    state: directory
+    owner: ubuntu
+    group: ubuntu
+    mode: '0755'

--- a/provisioning/subcase-1a/roles/reporting_workspace/tasks/main.yml
+++ b/provisioning/subcase-1a/roles/reporting_workspace/tasks/main.yml
@@ -1,0 +1,21 @@
+---
+- name: Install reporting workspace packages
+  ansible.builtin.apt:
+    name: "{{ reporting_workspace_packages | default(['postgresql', 'grafana']) }}"
+    state: present
+    update_cache: true
+
+- name: Ensure grafana service is enabled
+  ansible.builtin.service:
+    name: grafana-server
+    enabled: true
+    state: started
+  when: "'grafana' in (reporting_workspace_packages | default(['postgresql', 'grafana']))"
+
+- name: Create analytics data directory
+  ansible.builtin.file:
+    path: /var/lib/reporting-workspace
+    state: directory
+    owner: postgres
+    group: postgres
+    mode: '0750'

--- a/provisioning/subcase-1a/roles/trainee_workstation/tasks/main.yml
+++ b/provisioning/subcase-1a/roles/trainee_workstation/tasks/main.yml
@@ -1,0 +1,13 @@
+---
+- name: Ensure folders for trainee resources exist
+  ansible.windows.win_file:
+    path: "{{ item }}"
+    state: directory
+  loop: "{{ trainee_workspace_resources | default(['C:\\Labs', 'C:\\Labs\\Evidence']) }}"
+
+- name: Place orientation note for trainees
+  ansible.windows.win_copy:
+    dest: C:\Labs\WELCOME.txt
+    content: |
+      Welcome to the Random Education Platform phishing awareness lab.
+      Use the Evidence folder to store artefacts requested by the instructor.

--- a/provisioning/subcase-1a/site.yml
+++ b/provisioning/subcase-1a/site.yml
@@ -1,0 +1,24 @@
+---
+- name: Configure REP core services
+  hosts: rep_core
+  become: true
+  roles:
+    - role: rep_core
+
+- name: Prepare the reporting workspace analytics stack
+  hosts: reporting_workspace
+  become: true
+  roles:
+    - role: reporting_workspace
+
+- name: Personalise the instructor console
+  hosts: instructor_console
+  become: true
+  roles:
+    - role: instructor_console
+
+- name: Stage trainee lab resources
+  hosts: trainees
+  gather_facts: false
+  roles:
+    - role: trainee_workstation

--- a/provisioning/subcase-1d-topology.yml
+++ b/provisioning/subcase-1d-topology.yml
@@ -1,0 +1,97 @@
+name: subcase_1d_ng_soc_operation
+hosts:
+  - name: ng-soc
+    base_box:
+      image: ubuntu-noble-x86_64
+      mgmt_user: ubuntu
+    flavor: standard.medium
+  - name: ng-siem
+    base_box:
+      image: ubuntu-noble-x86_64
+      mgmt_user: ubuntu
+    flavor: standard.medium
+  - name: ng-soar
+    base_box:
+      image: ubuntu-noble-x86_64
+      mgmt_user: ubuntu
+    flavor: standard.medium
+  - name: cti-ss
+    base_box:
+      image: ubuntu-noble-x86_64
+      mgmt_user: ubuntu
+    flavor: standard.small
+  - name: cicms-operator
+    base_box:
+      image: ubuntu-noble-x86_64
+      mgmt_user: ubuntu
+    flavor: standard.small
+  - name: playbook-library
+    base_box:
+      image: ubuntu-noble-x86_64
+      mgmt_user: ubuntu
+    flavor: standard.small
+  - name: telemetry-simulator
+    base_box:
+      image: ubuntu-noble-x86_64
+      mgmt_user: ubuntu
+    flavor: standard.small
+routers:
+  - name: ng-ops-gateway
+    base_box:
+      image: debian-12-x86_64
+      mgmt_user: debian
+    flavor: standard.small
+networks:
+  - name: soc-operations
+    cidr: 10.30.10.0/24
+    accessible_by_user: False
+  - name: automation-zone
+    cidr: 10.30.20.0/24
+    accessible_by_user: False
+  - name: intelligence-zone
+    cidr: 10.30.30.0/24
+    accessible_by_user: False
+  - name: coordination-zone
+    cidr: 10.30.40.0/24
+    accessible_by_user: False
+  - name: telemetry-zone
+    cidr: 10.30.50.0/24
+    accessible_by_user: False
+net_mappings:
+  - host: ng-soc
+    network: soc-operations
+    ip: 10.30.10.10
+  - host: ng-siem
+    network: soc-operations
+    ip: 10.30.10.20
+  - host: ng-soar
+    network: automation-zone
+    ip: 10.30.20.10
+  - host: cti-ss
+    network: intelligence-zone
+    ip: 10.30.30.10
+  - host: playbook-library
+    network: intelligence-zone
+    ip: 10.30.30.20
+  - host: cicms-operator
+    network: coordination-zone
+    ip: 10.30.40.10
+  - host: telemetry-simulator
+    network: telemetry-zone
+    ip: 10.30.50.10
+router_mappings:
+  - router: ng-ops-gateway
+    network: soc-operations
+    ip: 10.30.10.1
+  - router: ng-ops-gateway
+    network: automation-zone
+    ip: 10.30.20.1
+  - router: ng-ops-gateway
+    network: intelligence-zone
+    ip: 10.30.30.1
+  - router: ng-ops-gateway
+    network: coordination-zone
+    ip: 10.30.40.1
+  - router: ng-ops-gateway
+    network: telemetry-zone
+    ip: 10.30.50.1

--- a/provisioning/subcase-1d/README.md
+++ b/provisioning/subcase-1d/README.md
@@ -1,0 +1,47 @@
+# Subcase 1d – Provisioning guide
+
+Automation assets for the NG-SOC ecosystem used during the playbook execution exercises. Each role prepares the baseline required to validate the end-to-end flow between NG-SIEM, NG-SOC, NG-SOAR, CTI-SS, CICMS Operator and the playbook library.
+
+## Host groups
+
+| Inventory group | Hosts | Purpose |
+| --- | --- | --- |
+| `ng_soc` | `ng-soc` | Analyst console and orchestration entry point. |
+| `ng_siem` | `ng-siem` | Event correlation and alerting platform. |
+| `ng_soar` | `ng-soar` | Automation engine running CACAO playbooks. |
+| `cti_ss` | `cti-ss` | Threat intelligence and indicator enrichment. |
+| `cicms` | `cicms-operator` | Incident coordination and documentation workspace. |
+| `playbook_library` | `playbook-library` | Standards repository (NVD/NIST, MITRE ATT&CK) and lessons learnt. |
+| `telemetry_feeder` | `telemetry-simulator` | Generates telemetry samples for NG-SIEM validation. |
+
+## Requirements
+
+- Ansible 2.15 or newer with the `community.general` collection available.
+- Access to the hosts defined in `provisioning/subcase-1d-topology.yml`.
+- Secrets managed through Ansible Vault or environment variables.
+
+Install the collection with:
+
+```bash
+ansible-galaxy collection install community.general
+```
+
+## Running the playbook
+
+```bash
+ansible-playbook -i inventory.yml provisioning/subcase-1d/site.yml
+```
+
+Use tags to execute individual components, e.g. `--tags ng_siem` to provision only the SIEM server.
+
+## Variables
+
+- `ng_soc_packages` (default `['docker.io', 'python3-pip']`)
+- `ng_siem_packages` (default `['openjdk-17-jdk', 'rsyslog']`)
+- `ng_soar_packages` (default `['python3-venv', 'redis-server']`)
+- `cti_ss_packages` (default `['python3-requests', 'jq']`)
+- `cicms_packages` (default `['postgresql-client', 'curl']`)
+- `playbook_library_packages` (default `['git', 'nginx']`)
+- `telemetry_feeder_packages` (default `['python3-venv', 'rsyslog']`)
+
+Set them per group to adapt the stack to each exercise iteration.

--- a/provisioning/subcase-1d/roles/cicms/tasks/main.yml
+++ b/provisioning/subcase-1d/roles/cicms/tasks/main.yml
@@ -1,0 +1,26 @@
+---
+- name: Install CICMS tooling
+  ansible.builtin.apt:
+    name: "{{ cicms_packages | default(['postgresql-client', 'curl']) }}"
+    state: present
+    update_cache: true
+
+- name: Create CICMS document repository
+  ansible.builtin.file:
+    path: /opt/cicms/documents
+    state: directory
+    owner: ubuntu
+    group: ubuntu
+    mode: '0755'
+
+- name: Deploy status template
+  ansible.builtin.copy:
+    dest: /opt/cicms/documents/status-template.md
+    content: |
+      # Incident status template
+      - Phase:
+      - Owner:
+      - Evidence reference:
+    owner: ubuntu
+    group: ubuntu
+    mode: '0644'

--- a/provisioning/subcase-1d/roles/cti_ss/tasks/main.yml
+++ b/provisioning/subcase-1d/roles/cti_ss/tasks/main.yml
@@ -1,0 +1,26 @@
+---
+- name: Install CTI-SS dependencies
+  ansible.builtin.apt:
+    name: "{{ cti_ss_packages | default(['python3-requests', 'jq']) }}"
+    state: present
+    update_cache: true
+
+- name: Configure indicator cache directory
+  ansible.builtin.file:
+    path: /opt/cti-ss/cache
+    state: directory
+    owner: ubuntu
+    group: ubuntu
+    mode: '0755'
+
+- name: Seed indicator catalogue
+  ansible.builtin.copy:
+    dest: /opt/cti-ss/cache/indicators.json
+    content: |
+      {
+        "description": "Sample CTI dataset for CyberRangeCZ exercises",
+        "indicators": []
+      }
+    owner: ubuntu
+    group: ubuntu
+    mode: '0644'

--- a/provisioning/subcase-1d/roles/ng_siem/tasks/main.yml
+++ b/provisioning/subcase-1d/roles/ng_siem/tasks/main.yml
@@ -1,0 +1,23 @@
+---
+- name: Install NG-SIEM packages
+  ansible.builtin.apt:
+    name: "{{ ng_siem_packages | default(['openjdk-17-jdk', 'rsyslog']) }}"
+    state: present
+    update_cache: true
+
+- name: Ensure rsyslog is enabled
+  ansible.builtin.service:
+    name: rsyslog
+    enabled: true
+    state: started
+
+- name: Deploy placeholder correlation profile
+  ansible.builtin.copy:
+    dest: /etc/ng-siem/correlation.conf
+    content: |
+      [default]
+      description = Sample correlation profile for CyberRangeCZ lab
+      enabled = true
+    owner: root
+    group: root
+    mode: '0644'

--- a/provisioning/subcase-1d/roles/ng_soar/tasks/main.yml
+++ b/provisioning/subcase-1d/roles/ng_soar/tasks/main.yml
@@ -1,0 +1,20 @@
+---
+- name: Install NG-SOAR packages
+  ansible.builtin.apt:
+    name: "{{ ng_soar_packages | default(['python3-venv', 'redis-server']) }}"
+    state: present
+    update_cache: true
+
+- name: Ensure redis is running
+  ansible.builtin.service:
+    name: redis-server
+    enabled: true
+    state: started
+
+- name: Create CACAO playbook directory
+  ansible.builtin.file:
+    path: /opt/ng-soar/playbooks
+    state: directory
+    owner: ubuntu
+    group: ubuntu
+    mode: '0755'

--- a/provisioning/subcase-1d/roles/ng_soc/tasks/main.yml
+++ b/provisioning/subcase-1d/roles/ng_soc/tasks/main.yml
@@ -1,0 +1,20 @@
+---
+- name: Install NG-SOC required packages
+  ansible.builtin.apt:
+    name: "{{ ng_soc_packages | default(['docker.io', 'python3-pip']) }}"
+    state: present
+    update_cache: true
+
+- name: Ensure docker service is running
+  ansible.builtin.service:
+    name: docker
+    enabled: true
+    state: started
+
+- name: Configure NG-SOC workspace directory
+  ansible.builtin.file:
+    path: /opt/ng-soc/workspace
+    state: directory
+    owner: ubuntu
+    group: ubuntu
+    mode: '0755'

--- a/provisioning/subcase-1d/roles/playbook_library/tasks/main.yml
+++ b/provisioning/subcase-1d/roles/playbook_library/tasks/main.yml
@@ -1,0 +1,27 @@
+---
+- name: Install playbook library packages
+  ansible.builtin.apt:
+    name: "{{ playbook_library_packages | default(['git', 'nginx']) }}"
+    state: present
+    update_cache: true
+
+- name: Ensure nginx service is enabled
+  ansible.builtin.service:
+    name: nginx
+    enabled: true
+    state: started
+
+- name: Publish reference index
+  ansible.builtin.copy:
+    dest: /var/www/html/index.html
+    content: |
+      <html>
+      <head><title>CyberRangeCZ Playbook Library</title></head>
+      <body>
+        <h1>CyberRangeCZ Playbook Library</h1>
+        <p>Use this portal to document CACAO playbooks, MITRE ATT&CK coverage and NVD/NIST references.</p>
+      </body>
+      </html>
+    owner: www-data
+    group: www-data
+    mode: '0644'

--- a/provisioning/subcase-1d/roles/telemetry_feeder/tasks/main.yml
+++ b/provisioning/subcase-1d/roles/telemetry_feeder/tasks/main.yml
@@ -1,0 +1,24 @@
+---
+- name: Install telemetry simulator packages
+  ansible.builtin.apt:
+    name: "{{ telemetry_feeder_packages | default(['python3-venv', 'rsyslog']) }}"
+    state: present
+    update_cache: true
+
+- name: Create telemetry scenario directory
+  ansible.builtin.file:
+    path: /opt/telemetry-simulator/scenarios
+    state: directory
+    owner: ubuntu
+    group: ubuntu
+    mode: '0755'
+
+- name: Provide sample log generator script
+  ansible.builtin.copy:
+    dest: /opt/telemetry-simulator/scenarios/generate.sh
+    content: |
+      #!/usr/bin/env bash
+      logger "CyberRangeCZ telemetry event: $(date --iso-8601=seconds)"
+    owner: ubuntu
+    group: ubuntu
+    mode: '0755'

--- a/provisioning/subcase-1d/site.yml
+++ b/provisioning/subcase-1d/site.yml
@@ -1,0 +1,49 @@
+---
+- name: Configure NG-SOC analyst console
+  hosts: ng_soc
+  become: true
+  roles:
+    - role: ng_soc
+      tags: ng_soc
+
+- name: Prepare NG-SIEM correlation engine
+  hosts: ng_siem
+  become: true
+  roles:
+    - role: ng_siem
+      tags: ng_siem
+
+- name: Deploy NG-SOAR automation stack
+  hosts: ng_soar
+  become: true
+  roles:
+    - role: ng_soar
+      tags: ng_soar
+
+- name: Enable CTI-SS enrichment services
+  hosts: cti_ss
+  become: true
+  roles:
+    - role: cti_ss
+      tags: cti_ss
+
+- name: Configure CICMS operator workspace
+  hosts: cicms
+  become: true
+  roles:
+    - role: cicms
+      tags: cicms
+
+- name: Publish playbook library portal
+  hosts: playbook_library
+  become: true
+  roles:
+    - role: playbook_library
+      tags: playbook_library
+
+- name: Start telemetry simulator feeds
+  hosts: telemetry_feeder
+  become: true
+  roles:
+    - role: telemetry_feeder
+      tags: telemetry_feeder


### PR DESCRIPTION
## Summary
- add dedicated KYPO topology definitions for the 1a phishing awareness and 1d NG-SOC subcases
- provide Ansible playbooks and roles to configure the hosts required by each subcase, including documentation per directory
- refresh the sample inventory and provisioning guide to explain execution and credential management steps

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d123c17804832d9cd8c5b6376f6f32